### PR TITLE
backport 1.2.2 to aarch64 and ppc64le

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bitarray" %}
-{% set version = "1.6.0" %}
+{% set version = "1.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ba157ddebddc723fe021fc80595b3c70924d69ee58286b62bfca21da48edfc9d
+  sha256: 27a69ffcee3b868abab3ce8b17c69e02b63e722d4d64ffd91d659f81e9984954
 
 build:
-  number: 0
+  number: 1 
   {% if 'pypy' in python %}
   # https://github.com/ilanschnell/bitarray/issues/99
   skip: true


### PR DESCRIPTION
Testing a backport for aarch64 and ppc64le versions of https://github.com/conda-forge/eth-account-feedstock

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
